### PR TITLE
Graceful degrades for Vim 7.2 (nornu, colorcolumn)

### DIFF
--- a/plugin/goyo.vim
+++ b/plugin/goyo.vim
@@ -46,8 +46,14 @@ function! s:init_pad(command)
   execute a:command
 
   setlocal buftype=nofile bufhidden=wipe nomodifiable nobuflisted noswapfile
-        \ nonu nornu nocursorline colorcolumn=
+        \ nonu nocursorline
         \ winfixwidth winfixheight statusline=\ 
+	if has ('nornu')
+		setlocal nornu
+	endif
+	if has ('colorcolumn')
+		setlocal colorcolumn=
+	endif
   let bufnr = winbufnr(0)
 
   execute winnr('#') . 'wincmd w'
@@ -153,9 +159,14 @@ function! s:goyo_on(width)
   endif
 
   if !get(g:, 'goyo_linenr', 0)
-    set nonu nornu
+    set nonu
   endif
-  set colorcolumn=
+  if !get(g:, 'goyo_linenr', 0) && has('nornu')
+    set nornu
+  endif
+	if has ('colorcolumn')
+		set colorcolumn=
+	endif
   set winwidth=1
   set winheight=1
   set laststatus=0


### PR DESCRIPTION
Vim 7.2 has neither colorcolumn nor nornu. This modification tests for the presence of each before trying to set them, preventing any error messages from appearing.
