### PR TITLE
Added example keybinding to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Usage
 
 `:Goyo [width]`
 
+You might map this to a key combo in your `.vimrc` like so:
+```vim
+"" Map Goyo toggle to <Leader> + spacebar
+nnoremap <Leader><Space> :Goyo<CR>  
+```
+
 Configuration
 -------------
 


### PR DESCRIPTION
I think it's helpful for less-experienced vim users (like many writers) to have an example like this laid out. Up to you if you want to include it or not though.

Thanks for the great plugin btw! The callbacks are a great feature. All the darkroom plugins screw up my colorscheme on exit -- but it's easy to fix it in the callback with yours.
