### PR TITLE
Added vim-signify to the list of toggled plugins

### DIFF
--- a/plugin/goyo.vim
+++ b/plugin/goyo.vim
@@ -147,9 +147,9 @@ function! s:goyo_on(width)
   endif
 
   " vim-signify
-  let t:goyo_disabled_signify = exists("b:sy")
+  let t:goyo_disabled_signify = exists('b:sy') && b:sy.active
   if t:goyo_disabled_signify
-    if (b:sy.active)|SignifyToggle|endif
+    SignifyToggle
   endif
 
   " vim-airline


### PR DESCRIPTION
Changes add toggle support for [vim-signify](https://github.com/mhinz/vim-signify), which is a plugin similar to vim-gitgutter that handles all the major VC systems.
