### PR TITLE
Disable vim-pandoc folding

### DIFF
--- a/plugin/goyo.vim
+++ b/plugin/goyo.vim
@@ -218,6 +218,12 @@ function! s:goyo_on(width)
     silent! call lightline#disable()
   endif
 
+  " vim-pandoc folding
+  let t:goyo_disabled_pandocfolding = &l:foldexpr == "pandoc#folding#FoldExpr()"
+  if t:goyo_disabled_pandocfolding
+      call pandoc#folding#Disable()
+  endif
+
   call s:hide_linenr()
   " Global options
   let &winheight = max([&winminheight, 1])
@@ -293,6 +299,7 @@ function! s:goyo_off()
   let goyo_disabled_airline   = t:goyo_disabled_airline
   let goyo_disabled_powerline = t:goyo_disabled_powerline
   let goyo_disabled_lightline = t:goyo_disabled_lightline
+  let goyo_disabled_pandocfolding = t:goyo_disabled_pandocfolding
   let goyo_orig_buffer        = t:goyo_master
   let [line, col]             = [line('.'), col('.')]
 
@@ -345,6 +352,10 @@ function! s:goyo_off()
 
   if goyo_disabled_lightline
     silent! call lightline#enable()
+  endif
+
+  if goyo_disabled_pandocfolding
+    silent! call pandoc#folding#Init()
   endif
 
   if exists('#Powerline')


### PR DESCRIPTION
Opening Goyo in a pandoc buffer causes slowness. I've tracked it down to some interaction between Goyo and vim-pandoc's folding module. It required it to be disabled before the Goyo is enabled (not sure why), so I had to include special code for it in goyo_on instead of using the callback method. 