### PR TITLE
Fix for lightline naming convention change

### DIFF
--- a/autoload/goyo.vim
+++ b/autoload/goyo.vim
@@ -34,7 +34,7 @@ endfunction
 
 function! s:set_color(group, attr, color)
   let gui = a:color =~ '^#'
-  execute printf("hi %s %s%s=%s", a:group, gui ? 'gui' : 'cterm', a:attr, a:color)
+  execute printf('hi %s %s%s=%s', a:group, gui ? 'gui' : 'cterm', a:attr, a:color)
 endfunction
 
 function! s:blank(repel)
@@ -207,13 +207,13 @@ function! s:goyo_on(dim)
   endif
 
   " vim-airline
-  let t:goyo_disabled_airline = exists("#airline")
+  let t:goyo_disabled_airline = exists('#airline')
   if t:goyo_disabled_airline
     AirlineToggle
   endif
 
   " vim-powerline
-  let t:goyo_disabled_powerline = exists("#PowerlineMain")
+  let t:goyo_disabled_powerline = exists('#PowerlineMain')
   if t:goyo_disabled_powerline
     augroup PowerlineMain
       autocmd!
@@ -330,7 +330,7 @@ function! s:goyo_off()
   let &winheight    = wh
 
   for [k, v] in items(goyo_revert)
-    execute printf("let &%s = %s", k, string(v))
+    execute printf('let &%s = %s', k, string(v))
   endfor
   execute 'colo '. get(g:, 'colors_name', 'default')
 
@@ -344,7 +344,7 @@ function! s:goyo_off()
     endif
   endif
 
-  if goyo_disabled_airline && !exists("#airline")
+  if goyo_disabled_airline && !exists('#airline')
     AirlineToggle
     " For some reason, Airline requires two refreshes to avoid display
     " artifacts
@@ -352,7 +352,7 @@ function! s:goyo_off()
     silent! AirlineRefresh
   endif
 
-  if goyo_disabled_powerline && !exists("#PowerlineMain")
+  if goyo_disabled_powerline && !exists('#PowerlineMain')
     doautocmd PowerlineStartup VimEnter
     silent! PowerlineReloadColorscheme
   endif

--- a/autoload/goyo.vim
+++ b/autoload/goyo.vim
@@ -222,7 +222,7 @@ function! s:goyo_on(dim)
   endif
 
   " lightline.vim
-  let t:goyo_disabled_lightline = exists('#LightLine')
+  let t:goyo_disabled_lightline = exists('#lightline')
   if t:goyo_disabled_lightline
     silent! call lightline#disable()
   endif


### PR DESCRIPTION
Four days ago, with the itchyny/lightline.vim@0f62126 commit, lightline.vim switched to using all lowercase letters for their augroups. Thus,

    if exists('#LightLine')

always returns `0`. I changed it to

    if exists('#lightline')

Also, there were a couple places that had double-quotes that could have had single-quotes (notably, the other `exists()` checks right about the one for lightline), so I swapped those over in the other commit.