### PR TITLE
Toggle tmux full-screen pane when entering and leaving Goyo

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ to be triggered on `GoyoEnter` and `GoyoLeave` events.
 ```vim
 function! s:goyo_enter()
   silent !tmux set status off
+  silent !tmux list-panes -F '\#F' | grep -q Z || tmux resize-pane -Z
   set noshowmode
   set noshowcmd
   set scrolloff=999
@@ -87,6 +88,7 @@ endfunction
 
 function! s:goyo_leave()
   silent !tmux set status on
+  silent !tmux list-panes -F '\#F' | grep -q Z && tmux resize-pane -Z
   set showmode
   set showcmd
   set scrolloff=5


### PR DESCRIPTION
Toggle full screen of current tmux pane when the user enters or leaves Goyo by using executing ` tmux resize-pane -Z` in `goyo_enter()` and `goyo_leave()`.