### PR TITLE
Neovim: Fix window resizing

### DIFF
--- a/autoload/goyo.vim
+++ b/autoload/goyo.vim
@@ -263,6 +263,10 @@ function! s:goyo_on(dim)
     autocmd ColorScheme *        call s:tranquilize()
     autocmd BufWinEnter *        call s:hide_linenr() | call s:hide_statusline()
     autocmd WinEnter,WinLeave *  call s:hide_statusline()
+    if has("nvim")
+      autocmd VimResized * normal =
+      autocmd TermClose * call feedkeys("\<C-w>=")
+    endif
   augroup END
 
   call s:hide_statusline()


### PR DESCRIPTION
- Add TermClose autocmd to adjust window size via <C-w>= after any
term:// buffer ends.
- Fix VimResized autocmd using "normal ^W=", because "wincmd =" is not working as expected in Neovim.

Resolves #97