### PR TITLE
Suppress W19 warning when closing goyo window with :q

### DIFF
--- a/autoload/goyo.vim
+++ b/autoload/goyo.vim
@@ -293,11 +293,11 @@ function! s:goyo_off()
   augroup goyo
     autocmd!
   augroup END
-  augroup! goyo
+  silent augroup! goyo
   augroup goyop
     autocmd!
   augroup END
-  augroup! goyop
+  silent augroup! goyop
 
   for c in t:goyo_maps
     execute 'nunmap <c-w>'.escape(c, '|')


### PR DESCRIPTION
I noticed that W19 warning always occurs when closing Goyo window with `:q`.

```
W19: Deleting augroup that is still in use
```

`:help W19` says that it's because autocmd command for `goyo` augroup is in use.  Actually, `s:goyo_off()` is called on `TabLeave`, which is hooked in `goyo` augroup.  I could not find the way to avoid this so I thought it's the best way for goyo.vim to suppress the warning.
