### PR TITLE
Fix set_color method

### DIFF
--- a/autoload/goyo.vim
+++ b/autoload/goyo.vim
@@ -33,7 +33,7 @@ function! s:get_color(group, attr)
 endfunction
 
 function! s:set_color(group, attr, color)
-  let gui = a:color =~ '^#'
+  let gui = has('gui_running') || has('termguicolors') && &termguicolors
   execute printf('hi %s %s%s=%s', a:group, gui ? 'gui' : 'cterm', a:attr, a:color)
 endfunction
 


### PR DESCRIPTION
Turns cterm and gui to None if attr is empty

Will fix #139