### PR TITLE
Fix `tmux` invocation conditions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ to be triggered on `GoyoEnter` and `GoyoLeave` events.
 
 ```vim
 function! s:goyo_enter()
-  silent !tmux set status off
-  silent !tmux list-panes -F '\#F' | grep -q Z || tmux resize-pane -Z
+  if executable('tmux') && strlen($TMUX)
+    silent !tmux set status off
+    silent !tmux list-panes -F '\#F' | grep -q Z || tmux resize-pane -Z
+  endif
   set noshowmode
   set noshowcmd
   set scrolloff=999
@@ -87,8 +89,10 @@ function! s:goyo_enter()
 endfunction
 
 function! s:goyo_leave()
-  silent !tmux set status on
-  silent !tmux list-panes -F '\#F' | grep -q Z && tmux resize-pane -Z
+  if executable('tmux') && strlen($TMUX)
+    silent !tmux set status on
+    silent !tmux list-panes -F '\#F' | grep -q Z && tmux resize-pane -Z
+  endif
   set showmode
   set showcmd
   set scrolloff=5


### PR DESCRIPTION
There are two cases where the current documentation would cause issues:
1. `tmux` isn't available in `$PATH`.
2. The current terminal isn' actually running `tmux`.