### PR TITLE
Add hide_statusline to write events.

### DIFF
--- a/autoload/goyo.vim
+++ b/autoload/goyo.vim
@@ -265,6 +265,7 @@ function! s:goyo_on(dim)
     autocmd ColorScheme *        call s:tranquilize()
     autocmd BufWinEnter *        call s:hide_linenr() | call s:hide_statusline()
     autocmd WinEnter,WinLeave *  call s:hide_statusline()
+    autocmd BufWriteCmd,FileWriteCmd *  call s:hide_statusline()
     if has('nvim')
       autocmd TermClose * call feedkeys("\<plug>(goyo-resize)")
     endif


### PR DESCRIPTION
Add hide_statusline call to BufWriteCmd and FileWriteCmd events.
Resolves issue in some configurations using lightline where statusline
reappears after writing file.