### PR TITLE
resize_pads exits early if no padding has been initialized

### DIFF
--- a/autoload/goyo.vim
+++ b/autoload/goyo.vim
@@ -83,6 +83,10 @@ function! s:setup_pad(bufnr, vert, size, repel)
 endfunction
 
 function! s:resize_pads()
+  if !exists('t:goyo_pads_setup') || !t:goyo_pads_setup
+    return
+  endif
+
   augroup goyop
     autocmd!
   augroup END
@@ -254,6 +258,7 @@ function! s:goyo_on(dim)
   let t:goyo_pads.r = s:init_pad('vertical botright new')
   let t:goyo_pads.t = s:init_pad('topleft new')
   let t:goyo_pads.b = s:init_pad('botright new')
+  let t:goyo_pads_setup = 1
 
   call s:resize_pads()
   call s:tranquilize()
@@ -376,6 +381,8 @@ function! s:goyo_off()
   if exists('#User#GoyoLeave')
     doautocmd User GoyoLeave
   endif
+
+  let t:goyo_pads_setup = 0
 endfunction
 
 function! s:relsz(expr, limit)


### PR DESCRIPTION
Hi there, this is a simple, somewhat hacky fix for a problem I ran into when initializing Goyo.

The problem I was running into was that I had an autocmd in my `.vimrc` to resize the windows to be evenly split on a `WinEnter` event. This lead to problems that I don't quite understand where `resize_pads` was called within `init_pads`; I don't understand it because it looks like Goyo doesn't add the autocmd for `resize_pads` until after `init_pads`, but somehow this got called anyways even on a fresh start of vim.

My fix to this was just to add a flag to verify that all `init_pad` calls have been run; if they haven't been, resize_pad returns without resizing. 

If you want to make a less hacky fix than the one I have here, I ran into this problem on neovim 0.3.1. The window resizing I am doing is somewhat indirect so that may also matter: I call a command from another plugin that happens to resize the windows in a specific way (`<Plug>(repl-resize)` in https://github.com/haberdashPI/vim-multi-repl).