### PR TITLE
Possible fix to #160 - Fix other side effects from resetting colorscheme

### DIFF
--- a/autoload/goyo.vim
+++ b/autoload/goyo.vim
@@ -132,8 +132,7 @@ function! s:untranquilize()
         execute 'hi clear ' . group.name ' | hi link ' . group.name . ' ' . group.links_to
       else
         let prefix = was_gui ? 'gui' : 'cterm'
-        let cmd = 'hi ' . group.name . ' ' . prefix . 'fg=' . group.fg . ' ' . prefix . 'bg=' . group.bg . ' ' . prefix . '=' . group.style_attrs 
-        execute cmd
+        execute 'hi ' . group.name . ' ' . prefix . 'fg=' . group.fg . ' ' . prefix . 'bg=' . group.bg . ' ' . prefix . '=' . group.style_attrs 
       endif
     endfor
     unlet s:tranq_revert

--- a/autoload/goyo.vim
+++ b/autoload/goyo.vim
@@ -402,7 +402,6 @@ function! s:goyo_off()
     execute printf('let &%s = %s', k, string(v))
   endfor
   call s:untranquilize()
-  "execute 'colo '. get(g:, 'colors_name', 'default')
 
   if goyo_disabled_gitgutter
     silent! GitGutterEnable

--- a/autoload/goyo.vim
+++ b/autoload/goyo.vim
@@ -32,6 +32,20 @@ function! s:get_color(group, attr)
   return synIDattr(synIDtrans(hlID(a:group)), a:attr)
 endfunction
 
+let s:style_attrs = ['bold', 'italic', 'reverse', 'inverse', 'standout', 'underline', 'undercurl']
+function! s:get_style_attrs(group)
+  let result = ''
+  for name in s:style_attrs
+    if synIDattr(a:group, name) == 1
+      let result .= name . ','
+    endif
+  endfor
+  if len(result) > 0
+    let result = result[:-2]
+  endif
+  return result
+endfunction
+
 function! s:set_color(group, attr, color)
   let gui = has('gui_running') || has('termguicolors') && &termguicolors
   execute printf('hi %s %s%s=%s', a:group, gui ? 'gui' : 'cterm', a:attr, a:color)
@@ -105,10 +119,60 @@ function! s:resize_pads()
   call s:setup_pad(t:goyo_pads.r, 1, hmargin - xoff, 'h')
 endfunction
 
+let s:tranq_grps = ['NonText', 'FoldColumn', 'ColorColumn', 'VertSplit',
+          \ 'StatusLine', 'StatusLineNC', 'SignColumn']
+"let s:tranq_revert = {'was_gui':0, 'groups': []}
+"
+function! s:untranquilize()
+  if exists("s:tranq_revert")
+    let was_gui = s:tranq_revert.was_gui
+    let groups = s:tranq_revert.groups
+    for group in groups
+      if group.links_to != ''
+        execute 'hi clear ' . group.name ' | hi link ' . group.name . ' ' . group.links_to
+      else
+        let prefix = was_gui ? 'gui' : 'cterm'
+        let cmd = 'hi ' . group.name . ' ' . prefix . 'fg=' . group.fg . ' ' . prefix . 'bg=' . group.bg . ' ' . prefix . '=' . group.style_attrs 
+        execute cmd
+      endif
+    endfor
+    unlet s:tranq_revert
+  endif
+endfunction
 function! s:tranquilize()
+  if exists('s:tranq_revert')
+    call s:untranquilize()
+  endif
   let bg = s:get_color('Normal', 'bg#')
-  for grp in ['NonText', 'FoldColumn', 'ColorColumn', 'VertSplit',
-            \ 'StatusLine', 'StatusLineNC', 'SignColumn']
+  let was_gui = has('gui_running') || has('termguicolors') && &termguicolors
+  let s:tranq_revert = {}
+  let s:tranq_revert.was_gui = was_gui
+  let s:tranq_revert.groups = []
+  let revert_grps = s:tranq_revert.groups
+  for grp in s:tranq_grps
+    let grp_id = hlID(grp)
+    let trans_id = synIDtrans(grp_id)
+    let revert_grp = {}
+    let revert_grp.id = grp_id
+    let revert_grp.name = synIDattr(grp_id, 'name')
+    call add(revert_grps, revert_grp)
+    if trans_id != grp_id
+      let revert_grp.links_to = synIDattr(trans_id, 'name')
+    else
+      let revert_grp.links_to = ''
+      let revert_grp.fg = synIDattr(trans_id, 'fg')
+      let revert_grp.bg = synIDattr(trans_id, 'bg')
+      let revert_grp.style_attrs = s:get_style_attrs(trans_id)
+      if revert_grp.fg == ''
+        let revert_grp.fg = 'NONE'
+      endif
+      if revert_grp.bg == ''
+        let revert_grp.bg = 'NONE'
+      endif
+      if revert_grp.style_attrs == ''
+        let revert_grp.style_attrs = 'NONE'
+      endif
+    endif
     " -1 on Vim / '' on GVim
     if bg == -1 || empty(bg)
       call s:set_color(grp, 'fg', get(g:, 'goyo_bg', 'black'))
@@ -337,7 +401,8 @@ function! s:goyo_off()
   for [k, v] in items(goyo_revert)
     execute printf('let &%s = %s', k, string(v))
   endfor
-  execute 'colo '. get(g:, 'colors_name', 'default')
+  call s:untranquilize()
+  "execute 'colo '. get(g:, 'colors_name', 'default')
 
   if goyo_disabled_gitgutter
     silent! GitGutterEnable


### PR DESCRIPTION
Hi there -- this is an attempt to remove the colorscheme reset in goyo.vim.  There are a number of side effects caused by resetting the colorscheme (reset of user highlights + incorrect highlights are sometimes reset)

I haven't tested this PR much other than just to verify that the basic functionality is working both within vim, neovim, gui, and terminal and that user highlights are no longer blown away.

The code could be cleaned up a bit - but wanted to see if there was any interest before moving any further with it.