### PR TITLE
Allow 'goyo.txt' to be listed in the LOCAL ADDITIONS section of help.txt

### DIFF
--- a/doc/goyo.txt
+++ b/doc/goyo.txt
@@ -1,4 +1,4 @@
-goyo.txt	goyo	Last change: April 2 2017
+*goyo.txt*	goyo	Last change: April 2 2017
 GOYO - TABLE OF CONTENTS                                         *goyo* *goyo-toc*
 ==============================================================================
 


### PR DESCRIPTION
The first field on the first line of a help file should be a link to the
help file name. (See :h help-writing)