### PR TITLE
Add ++nested modifier to TabLeave autocommand

### DIFF
--- a/autoload/goyo.vim
+++ b/autoload/goyo.vim
@@ -260,7 +260,7 @@ function! s:goyo_on(dim)
 
   augroup goyo
     autocmd!
-    autocmd TabLeave    *        call s:goyo_off()
+    autocmd TabLeave    *        ++nested call s:goyo_off()
     autocmd VimResized  *        call s:resize_pads()
     autocmd ColorScheme *        call s:tranquilize()
     autocmd BufWinEnter *        call s:hide_linenr() | call s:hide_statusline()

--- a/autoload/goyo.vim
+++ b/autoload/goyo.vim
@@ -260,7 +260,7 @@ function! s:goyo_on(dim)
 
   augroup goyo
     autocmd!
-    autocmd TabLeave    *        ++nested call s:goyo_off()
+    autocmd TabLeave    * nested call s:goyo_off()
     autocmd VimResized  *        call s:resize_pads()
     autocmd ColorScheme *        call s:tranquilize()
     autocmd BufWinEnter *        call s:hide_linenr() | call s:hide_statusline()


### PR DESCRIPTION
This allows autocommands to fire for commands during s:goyo_off.

A prominent example would be any autocommands user's installed on the
ColorScheme event (e.g., to set User highlights, like I do in my Dotfiles)

This *should* provide a fix for #160. Of note, I only see issues in my statusline (which uses `User` highlights) when I hit e.g. `gt` from goyo—when I close the tab with `:quit`, everything works fine. So I've only added the nested modifier here.