### PR TITLE
add filetype=goyo_pad to padding buffers

### DIFF
--- a/autoload/goyo.vim
+++ b/autoload/goyo.vim
@@ -50,6 +50,7 @@ function! s:init_pad(command)
 
   setlocal buftype=nofile bufhidden=wipe nomodifiable nobuflisted noswapfile
       \ nonu nocursorline nocursorcolumn winfixwidth winfixheight statusline=\ 
+      \ filetype=goyo_pad
   if exists('&rnu')
     setlocal nornu
   endif


### PR DESCRIPTION
This allows plugins like numbers.vim to be configured
to ignore the padding buffers.

It also allows users to set autocommands based on the filetype
on padding buffers to customize them further.