### PR TITLE
Fix signify detection

### DIFF
--- a/autoload/goyo.vim
+++ b/autoload/goyo.vim
@@ -203,7 +203,7 @@ function! s:goyo_on(dim)
   endif
 
   " vim-signify
-  let t:goyo_disabled_signify = exists('b:sy') && b:sy.active
+  let t:goyo_disabled_signify = !empty(getbufvar(bufnr(''), 'sy'))
   if t:goyo_disabled_signify
     SignifyToggle
   endif


### PR DESCRIPTION
Update vim-signify detection.

This is the same method [signify itself uses](https://github.com/mhinz/vim-signify/blob/master/autoload/sy.vim#L108).

Fixes #222 