### PR TITLE
Add loaded variable

### DIFF
--- a/plugin/goyo.vim
+++ b/plugin/goyo.vim
@@ -21,4 +21,9 @@
 " OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 " WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+if exists('g:loaded_goyo')
+  finish
+endif
+let g:loaded_goyo = 1
+
 command! -nargs=? -bar -bang Goyo call goyo#execute(<bang>0, <q-args>)


### PR DESCRIPTION
Creates variable `g:loaded_goyo`. This has a few benefits:

1. It guards the file from being loaded multiple times.
2. It gives plugin authors a convenient and standardized method to check if Goyo is loaded.