### PR TITLE
Allow `b:` variables, respect `'textwidth'`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,12 @@ Goyo 50%+25%x50%-25%
 Configuration
 -------------
 
-- `g:goyo_width` (default: 80)
-- `g:goyo_height` (default: 85%)
-- `g:goyo_linenr` (default: 0)
+The `b:` variables take precedence over the `g:` variables, if present.
+
+ - `b:goyo_width`, `g:goyo_width` (default: value of `'textwidth'`, or 80 if
+   unset)
+ - `b:goyo_height`, `g:goyo_height` (default: 85%)
+ - `b:goyo_linenr`, `g:goyo_linenr` (default: 0)
 
 ### Callbacks
 

--- a/autoload/goyo.vim
+++ b/autoload/goyo.vim
@@ -126,7 +126,7 @@ function! s:hide_statusline()
 endfunction
 
 function! s:hide_linenr()
-  if !get(g:, 'goyo_linenr', 0)
+  if !get(b:, 'goyo_linenr', get(g:, 'goyo_linenr', 0))
     setlocal nonu
     if exists('&rnu')
       setlocal nornu
@@ -386,8 +386,10 @@ function! s:relsz(expr, limit)
 endfunction
 
 function! s:parse_arg(arg)
-  if exists('g:goyo_height') || !exists('g:goyo_margin_top') && !exists('g:goyo_margin_bottom')
-    let height = s:relsz(get(g:, 'goyo_height', '85%'), &lines)
+  if exists('b:goyo_height') || exists('g:goyo_height') ||
+        \ (!exists('g:goyo_margin_top') && !exists('g:goyo_margin_bottom'))
+    let goyo_height = get(b:, 'goyo_height', get(g:, 'goyo_height', '85%'))
+    let height = s:relsz(goyo_height, &lines)
     let yoff = 0
   else
     let top = max([0, s:relsz(get(g:, 'goyo_margin_top', 4), &lines)])
@@ -396,7 +398,11 @@ function! s:parse_arg(arg)
     let yoff = top - bot
   endif
 
-  let dim = { 'width':  s:relsz(get(g:, 'goyo_width', 80), &columns),
+  " Add 1 otherwise the viewport will be off-by-one and cause lines to wrap
+  " even if something like `gq` would not have wrapped the line.
+  let default_width = &textwidth != 0 ? &textwidth + 1 : 80
+  let goyo_width = get(b:, 'goyo_width', get(g:, 'goyo_width', default_width))
+  let dim = { 'width':  s:relsz(goyo_width, &columns),
             \ 'height': height,
             \ 'xoff':   0,
             \ 'yoff':   yoff }

--- a/doc/goyo.txt
+++ b/doc/goyo.txt
@@ -81,11 +81,16 @@ prefixed by `+` or `-`. Each component can be given in percentage.
 CONFIGURATION                                               *goyo-configuration*
 ==============================================================================
 
+                                      *b:goyo_width* *b:goyo_height* *b:goyo_linenr*
                                       *g:goyo_width* *g:goyo_height* *g:goyo_linenr*
 
- - `g:goyo_width` (default: 80)
- - `g:goyo_height` (default: 85%)
- - `g:goyo_linenr` (default: 0)
+The `b:` variables take precedence over the `g:` variables, if present. See
+|buffer-variable| for more.
+
+ - `b:goyo_width`, `g:goyo_width` (default: value of 'textwidth', or 80 if
+   unset)
+ - `b:goyo_height`, `g:goyo_height` (default: 85%)
+ - `b:goyo_linenr`, `g:goyo_linenr` (default: 0)
 
 
 < Callbacks >_________________________________________________________________~


### PR DESCRIPTION
This PR implements two somewhat orthogonal changes.

If you'd like to only have one of these changes but not the other, I'm
happy to split this PR up and send the changes individually, but since
the two of them together would have merge conflicts independently, I've
authored them in a single PR.

The two changes:

1.  Allow `b:` variants of the documented configuration variables.
    This allows setting things like `goyo_width` to different settings
    in different file types or different buffers, by setting a
    buffer-scoped variable.

2.  Default `goyo_width` to `&textwidth + 1` if it is set and neither
    `b:goyo_width` nor `g:goyo_width` are set. The `+ 1` is to handle an
    off-by-one error where for a line that has exactly `&textwidth`
    characters, goyo would force the line to wrap.

I've been using these changes locally for some files where I have
`textwidth` set to values larger and smaller than 80, and have been
working well.

- - - - -

Thanks for your work on Goyo by the way—it makes writing in Vim rather
enjoyable.