### PR TITLE
Draw decorative elements in the pads

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Configuration
 - `g:goyo_width` (default: 80)
 - `g:goyo_height` (default: 85%)
 - `g:goyo_linenr` (default: 0)
+- `g:goyo_decoration_elements` (default: ['~', '~~'])
+- `g:goyo_decoration_density` (default: 0.00, range 0.00-1.00)
 
 ### Callbacks
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Configuration
 - `g:goyo_width` (default: 80)
 - `g:goyo_height` (default: 85%)
 - `g:goyo_linenr` (default: 0)
-- `g:goyo_decoration_elements` (default: ['~', '~~'])
+- `g:goyo_decoration_elements` (default: ['~'])
 - `g:goyo_decoration_density` (default: 0.00, range 0.00-1.00)
 
 ### Callbacks

--- a/autoload/goyo.vim
+++ b/autoload/goyo.vim
@@ -69,7 +69,7 @@ function! s:decorate()
   for line_num in range(win_height)
     let random_line = ''
     for i in range(win_width / grid_width + 1)
-      if (rand() % 100) < (density * 100)
+      if (rand() % 10000) < (density * 10000)
         let element = elements[rand() % elements_count]
         " Normalise the element width by padding it with spaces to place it
         " somewhere random in the cell

--- a/autoload/goyo.vim
+++ b/autoload/goyo.vim
@@ -57,6 +57,7 @@ function! s:decorate()
 
   let elements = get(g:, 'goyo_decoration_elements', ['~'])
   " Normalise our grid to the length of the longest element
+  let elements = map(copy(elements), {_, element -> printf('%1s', element)})
   let grid_width = max(map(copy(elements), {_, element -> len(element)}))
   let elements_count = len(elements)
   let blank = ''

--- a/autoload/goyo.vim
+++ b/autoload/goyo.vim
@@ -47,6 +47,49 @@ function! s:blank(repel)
   execute 'noautocmd wincmd' a:repel
 endfunction
 
+function! s:decorate()
+  let save_scroll = getcurpos()[1]
+
+  setlocal nowrap
+
+  let win_width = winwidth(0)
+  let win_height = winheight(0)
+
+  let elements = get(g:, 'goyo_decoration_elements', ['~', '~~'])
+  " Normalise our grid to the length of the longest element
+  let grid_width = max(map(copy(elements), {_, element -> len(element)}))
+  let elements_count = len(elements)
+  let blank = ''
+  for i in range(0, grid_width - 1)
+    let blank = blank . ' '
+  endfor
+  let density = get(g:, 'goyo_decoration_density', 0.0)
+
+  for line_num in range(win_height)
+    let random_line = ''
+    for i in range(win_width / grid_width + 1)
+      if (rand() % 100) < (density * 100)
+        let element = elements[rand() % elements_count]
+        " Normalise the element width by padding it with spaces to place it
+        " somewhere random in the cell
+        let length_diff = grid_width - len(element)
+        if length_diff > 0
+          let left = (rand() % length_diff)
+          let right = length_diff - left
+          let element = repeat(' ', left) . element . repeat(' ', right)
+        endif
+        let random_line .= element
+      else
+        let random_line .= blank
+      endif
+    endfor
+    let random_line = random_line[0:win_width - 3]
+    call append(line_num, random_line)
+  endfor
+
+  execute save_scroll . 'normal! zz'
+endfunction
+
 function! s:init_pad(command)
   execute a:command
 
@@ -81,6 +124,14 @@ function! s:setup_pad(bufnr, vert, size, repel)
     normal! gg
     setlocal nomodifiable
   endif
+
+  if get(g:, 'goyo_decoration_density') > 0.0
+    setlocal modifiable
+    call s:decorate()
+    normal! gg
+    setlocal nomodifiable
+  endif
+
   execute winnr('#') . 'wincmd w'
 endfunction
 

--- a/autoload/goyo.vim
+++ b/autoload/goyo.vim
@@ -55,7 +55,7 @@ function! s:decorate()
   let win_width = winwidth(0)
   let win_height = winheight(0)
 
-  let elements = get(g:, 'goyo_decoration_elements', ['~', '~~'])
+  let elements = get(g:, 'goyo_decoration_elements', ['~'])
   " Normalise our grid to the length of the longest element
   let grid_width = max(map(copy(elements), {_, element -> len(element)}))
   let elements_count = len(elements)

--- a/doc/goyo.txt
+++ b/doc/goyo.txt
@@ -1,4 +1,4 @@
-*goyo.txt*	goyo	Last change: April 2 2017
+*goyo.txt*	goyo	Last change: Dec 21 2025
 GOYO - TABLE OF CONTENTS                                         *goyo* *goyo-toc*
 ==============================================================================
 
@@ -12,7 +12,7 @@ GOYO - TABLE OF CONTENTS                                         *goyo* *goyo-to
     Pros.
     License
 
-GOYO.VIM (고요)                                                         *goyo-vim*
+GOYO.VIM (고요)                                                       *goyo-vim*
 ==============================================================================
 
 Distraction-free writing in Vim.
@@ -82,7 +82,7 @@ CONFIGURATION                                               *goyo-configuration*
 ==============================================================================
 
                                       *g:goyo_width* *g:goyo_height* *g:goyo_linenr*
-                            *g:goyo_decoration_elements* *g:goyo_decoration_density*
+                          *g:goyo_decoration_elements* *g:goyo_decoration_density*
 
  - `g:goyo_width` (default: 80)
  - `g:goyo_height` (default: 85%)

--- a/doc/goyo.txt
+++ b/doc/goyo.txt
@@ -82,10 +82,13 @@ CONFIGURATION                                               *goyo-configuration*
 ==============================================================================
 
                                       *g:goyo_width* *g:goyo_height* *g:goyo_linenr*
+                            *g:goyo_decoration_elements* *g:goyo_decoration_density*
 
  - `g:goyo_width` (default: 80)
  - `g:goyo_height` (default: 85%)
  - `g:goyo_linenr` (default: 0)
+ - `g:goyo_decoration_elements` (default: ['~', '~~'])
+ - `g:goyo_decoration_density` (default: 0.00, range 0.00-1.00)
 
 
 < Callbacks >_________________________________________________________________~

--- a/doc/goyo.txt
+++ b/doc/goyo.txt
@@ -87,7 +87,7 @@ CONFIGURATION                                               *goyo-configuration*
  - `g:goyo_width` (default: 80)
  - `g:goyo_height` (default: 85%)
  - `g:goyo_linenr` (default: 0)
- - `g:goyo_decoration_elements` (default: ['~', '~~'])
+ - `g:goyo_decoration_elements` (default: ['~'])
  - `g:goyo_decoration_density` (default: 0.00, range 0.00-1.00)
 
 


### PR DESCRIPTION
This adds a frivolous decorative element to add some peaceful \~waves\~ to the surrounding blank space.

Features:

- Optional (default off).
- Decorative string is customisable (some nice ones to try: `/`, `.`, `*`, `†`) and can be of arbitrary length.
- Rarity is customisable (higher number = fewer characters drawn).

<img width="953" height="796" alt="image" src="https://github.com/user-attachments/assets/02744ea9-3aae-4f21-99a2-d9685ed6ddaf" />
